### PR TITLE
Set eslint forbid-prop-types에서 array, object 제거

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,14 @@
   },
   "extends": ["airbnb", "plugin:prettier/recommended"],
   "rules": {
-    "react/jsx-props-no-spreading": "off"
+    "react/jsx-props-no-spreading": "off",
+    "react/forbid-prop-types": [
+      true,
+      {
+        "forbid": ["any"],
+        "checkContextTypes": true,
+        "checkChildContextTypes": true
+      }
+    ]
   }
 }


### PR DESCRIPTION
## What is this PR?🔍
`.eslintrc.json` rule 추가

## Changes or Description📝
forbid-prop-types에서 기본 [any, array, object] 로 적용되어 있는 부분에서 [any]로 변경

- 참고자료  
[Disallow certain propTypes (react/forbid-prop-types)
](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md)

array, object를 적었을 때 에러를 내는 이유가
array의 경우
```
array of objects [{name:'ABC'},{name:'XYZ'}]
array of strings ['Lorem','Ipsum']
array of integers [2,4,66,4]
array of nested arrays [['d'],[[{name:'a'},{name:'b'}]]]
array of functions [foo,bar]
```
이 항목들이 다 해당되기 때문에 좀 더 구체적으로 타입을 설정해주기 위해서 에러를 내는 거래요
array의 경우 PropTypes.arrayOf(PropTypes.object).isRequired
이런 식으로 작성하면 된다고 하네요. 저희는 린트 옵션에서 제외했지만 알고 넘어가시면 좋을 것 같아 공유드립니다!

